### PR TITLE
Remove unnecessary maven options on building

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,7 @@ jobs:
           wget https://archive.apache.org/dist/kyuubi/kyuubi-${KYUUBI_VERSION}/apache-kyuubi-${KYUUBI_VERSION}-source.tgz
           tar -xvf apache-kyuubi-${KYUUBI_VERSION}-source.tgz
           cd apache-kyuubi-${KYUUBI_VERSION}-source
-          ./build/dist ${{ matrix.opts }} -Dmaven.javadoc.skip=true -Dmaven.scaladoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests
+          ./build/dist ${{ matrix.opts }}
           cd ..
           docker build --tag apache/kyuubi:${KYUUBI_VERSION}${{ matrix.suffix-name }} --file ${KYUUBI_VERSION}/*/Dockerfile apache-kyuubi-${KYUUBI_VERSION}-source/dist
       - name: Validate docker image


### PR DESCRIPTION
those options are handled by `build/dist` internally