### PR TITLE
Publish multi-arch (amd64 + arm64) release images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -46,12 +46,16 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build Kyuubi Docker Image
+      - name: Build and push Kyuubi Docker image
         run: |
           # See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
           function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
@@ -65,8 +69,10 @@ jobs:
           cd apache-kyuubi-${KYUUBI_VERSION}-source
           ./build/dist ${{ matrix.opts }} $extra_build_args
           cd ..
-          docker build --tag apache/kyuubi:${KYUUBI_VERSION}${{ matrix.suffix-name }} --file ${KYUUBI_VERSION}/*/Dockerfile apache-kyuubi-${KYUUBI_VERSION}-source/dist
-      - name: Validate docker image
-        run: docker images
-      - name: Push Docker image
-        run: docker push apache/kyuubi:$(cat release/release_version)${{ matrix.suffix-name }}
+          # buildx builds and pushes the multi-arch manifest list in one step (it cannot be loaded locally)
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag apache/kyuubi:${KYUUBI_VERSION}${{ matrix.suffix-name }} \
+            --file ${KYUUBI_VERSION}/*/Dockerfile \
+            --push \
+            apache-kyuubi-${KYUUBI_VERSION}-source/dist


### PR DESCRIPTION
## What

Switch the release image publish workflow (`.github/workflows/docker-image.yml`) from single-arch `docker build` + `docker push` to `docker buildx build --platform linux/amd64,linux/arm64 --push`, adding the QEMU + Buildx setup steps.

## Why

All released `apache/kyuubi` tags (e.g. `1.11.x`, and the `-spark`/`-flink`/`-all` variants) are currently **amd64-only**. Snapshot images (`apache/kyuubi:master-snapshot`) have been multi-arch since KYUUBI #4576 / #4577, but that change only covered the snapshot workflow in `apache/kyuubi`; the release images published from this repo were never converted. ARM support is still an open, unanswered ask in discussion apache/kyuubi#4487.

This completes the release-image half of apache/kyuubi#4576.

## How it works

The distribution is built once on the native (amd64) runner via `./build/dist` — Kyuubi/Spark/Flink are pure-JVM, architecture-independent artifacts — and the same dist is assembled onto the multi-arch `eclipse-temurin:8` base for both platforms. So buildx only emulates the small `apt` layer + `COPY` for `linux/arm64`; there's no cross-compiled native code. The combined build-and-push replaces the separate validate/push steps because a multi-arch manifest list cannot be loaded into the local Docker daemon.

## Testing

- Verified `eclipse-temurin:8-jdk-focal` (the release Dockerfile base) publishes both `linux/amd64` and `linux/arm64`.
- Built the release Dockerfile for both platforms locally with the same `buildx --platform linux/amd64,linux/arm64` invocation; the arm64 image assembles correctly (base + apt layer + dist copy) and produces a valid manifest list.
- Validated that the multi-arch upstream Kyuubi image runs on arm64 end-to-end: deployed `apache/kyuubi:master-snapshot` (the existing multi-arch artifact) on an arm64 (AWS Graviton) Kubernetes node and ran a Spark query (`SELECT 1`) through the Thrift frontend to completion.

Reviewers: this only changes the publish workflow; the per-version Dockerfiles are untouched.

## Note for maintainers: CI coverage

This publish workflow only triggers on `push: tags`, so the change isn't exercised on PRs — it's first run when a release is cut. This repo currently has no `pull_request`-triggered CI, so I've left it that way to match the existing convention rather than introduce new CI unilaterally.

If you'd like automated coverage, I'm happy to add a lightweight `pull_request` job that runs the same multi-arch `buildx build` **without `--push`** (no Docker Hub credentials required) for one variant, so the multi-arch build is validated on every PR and before each release. Let me know your preference.